### PR TITLE
Add evidence-backed file checker to Similar Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You can also submit the currently playing or the currently opened artist anonymo
 
 ## Similar Projects
 - [SubmitHub AI Song Checker](https://www.submithub.com/story/ai-song-checker) – Tool to detect AI-generated songs
+- [AI Music Detector](https://www.aimusicdetect.com/) – File-upload checker with a public 60-track benchmark and downloadable per-track data.
 - [AI-Music Detection](https://github.com/deezer/ismir25-ai-music-detector) – Code for Deezer’s AI music tagging system
 - [Identifying Counterfeit Songs](https://openreview.net/forum?id=PY7KSh29Z8) – Paper about large-scale AI song detection datasets
 - [Using AI To Detect AI Music](https://www.youtube.com/watch?v=QVXfcIb3OKo) – YouTube video on identifying AI music


### PR DESCRIPTION
This adds one file-upload detector to the existing Similar Projects list. Unlike the Spotify artist blocklist, it analyzes an authorized audio file and returns a probability estimate. The site publishes a dated 60-track benchmark, downloadable per-track results, and limitations. No project code or behavior is changed.